### PR TITLE
Add user account deletion with password verification

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,5 +1,5 @@
 import User from '../models/User.js';
-import { hashPassword } from '../config/auth.js';
+import { hashPassword, comparePassword } from '../config/auth.js';
 
 export const getProfile = async (req, res) => {
   try {
@@ -49,5 +49,39 @@ export const updateProfile = async (req, res) => {
   } catch (error) {
     console.error("Error al actualizar el perfil:", error.message);
     res.status(500).json({ error: true, message: "Algo salió mal, por favor intenta más tarde." });
+  }
+};
+
+export const deleteAccount = async (req, res) => {
+  const userId = req.user.id;
+  const { password } = req.body;
+
+  if (!password) {
+    return res.status(200).json({ success: false, message: 'La contraseña es requerida.' });
+  }
+
+  try {
+    const user = await User.findByIdWithPassword(userId);
+
+    if (!user) {
+      return res.status(200).json({ success: false, message: 'Usuario no encontrado.' });
+    }
+
+    const isMatch = await comparePassword(password, user.password);
+
+    if (!isMatch) {
+      return res.status(200).json({ success: false, message: 'Contraseña incorrecta.' });
+    }
+
+    const deleted = await User.deleteById(userId);
+
+    if (!deleted) {
+      return res.status(500).json({ success: false, message: 'Error al eliminar la cuenta.' });
+    }
+
+    return res.status(200).json({ success: true, message: 'Cuenta eliminada correctamente.' });
+  } catch (error) {
+    console.error('Error al eliminar la cuenta:', error.message);
+    return res.status(500).json({ success: false, message: 'Error del servidor.' });
   }
 };

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -35,8 +35,33 @@ class User {
     return new User(result.rows[0]);
   }
 
+  // Find user by username and security question/answer
+  static async findByUsernameAndSecurity(username, question, answer) {
+    const result = await client.execute({
+      sql: `
+        SELECT * FROM users
+        WHERE username = ? AND security_question = ? AND security_answer = ?
+      `,
+      args: [username, question, answer],
+    });
 
- // Update user by ID
+    return result.rows[0]; // return user if found, otherwise undefined
+  }
+
+  // Find user by ID with password (for authentication)
+  static async findByIdWithPassword(id) {
+    try {
+      const sql = 'SELECT id, password FROM users WHERE id = ?';
+      const { rows } = await client.execute({ sql, args: [id] });
+
+      return rows.length ? rows[0] : null;
+    } catch (error) {
+      console.error('Error al buscar usuario con contraseña:', error.message);
+      throw error;
+    }
+  }
+
+  // Update user by ID
   static async updateById(id, fields) {
     const keys = Object.keys(fields);
     const values = Object.values(fields);
@@ -62,19 +87,8 @@ class User {
   }
 }
 
-  static async findByUsernameAndSecurity(username, question, answer) {
-    const result = await client.execute({
-      sql: `
-        SELECT * FROM users
-        WHERE username = ? AND security_question = ? AND security_answer = ?
-      `,
-      args: [username, question, answer],
-    });
-
-    return result.rows[0]; // return user if found, otherwise undefined
-  }
-
-    static async updatePassword(id, newPassword) {
+  // Update user password
+  static async updatePassword(id, newPassword) {
     await client.execute({
       sql: `
         UPDATE users SET password = ?
@@ -82,6 +96,18 @@ class User {
       `,
       args: [newPassword, id],
     });
+  }
+
+  // Delete user by ID
+  static async deleteById(id) {
+    try {
+      const sql = 'DELETE FROM users WHERE id = ?';
+      await client.execute({ sql, args: [id] });
+      return true;
+    } catch (error) {
+      console.error('Error al eliminar el usuario:', error.message);
+      throw error;
+    }
   }
 
   // Save new user to the database

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -10,4 +10,7 @@ router.get('/profile', authenticateToken, UserController.getProfile);
 // Update user profile
 router.put('/profile', authenticateToken, UserController.updateProfile);
 
+// Delete user account
+router.delete('/deleteAccount', authenticateToken, UserController.deleteAccount);
+
 export default router;


### PR DESCRIPTION
This PR introduces secure account deletion functionality, allowing users to delete their accounts only after verifying their password.

🔐 Key changes:
- Adds a new DELETE `/api/user/deleteAccount` endpoint.
- Implements password verification before deletion.
- Extends the User model with methods to:
  - Find a user by ID including the password field.
  - Delete a user by ID.
- Enhances security and ensures users have full control over their account.

This feature improves user autonomy and aligns with best practices for sensitive operations.
