### PR TITLE
Include user details in reserved cards response

### DIFF
--- a/backend/src/models/BingoCard.js
+++ b/backend/src/models/BingoCard.js
@@ -72,14 +72,22 @@ export class BingoCard {
 
   static async findReservedCards() {
     const query = `
-      SELECT bc.id, bc.numbers, r.user_id, r.date, r.payment_status
+      SELECT 
+        bc.id AS card_id, 
+        bc.numbers, 
+        r.user_id, 
+        u.username, 
+        u.phone, 
+        r.date, 
+        r.payment_status
       FROM bingo_cards bc
       JOIN reservations r ON bc.id = r.card_id
+      JOIN users u ON r.user_id = u.id
       WHERE r.payment_status = 'pending'
     `;
     return await client.execute({ sql: query });
   }
-
+  
   static async countPaidReservationsByUser(userId) {
     const query = `
       SELECT COUNT(*) AS total


### PR DESCRIPTION
This pull request enhances the reservation functionality by including additional user details in the response.

Changes:
- Updated the `findReservedCards` model method to join with the `users` table.
- Now returns `username` and `phone` along with `user_id` for each reserved card.

This provides clearer context in the UI and improves traceability of reserved cards by linking them to user identities.