### PR TITLE
Add pattern creation and retrieval endpoints

### DIFF
--- a/backend/src/controllers/bingoPatternController.js
+++ b/backend/src/controllers/bingoPatternController.js
@@ -1,0 +1,27 @@
+import { BingoPattern } from '../models/BingoPattern.js';
+
+export const createPattern = async (req, res) => {
+  try {
+    const { name, description, pattern } = req.body;
+
+    if (!name || !description || !pattern) {
+      return res.status(200).json({ error: 'Todos los campos son obligatorios.' });
+    }
+
+    await BingoPattern.create(name, description, pattern);
+    res.status(200).json({ message: 'Patrón creado exitosamente.' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Algo salió mal.' });
+  }
+};
+
+export const getAllPatterns = async (req, res) => {
+  try {
+    const patterns = await BingoPattern.findAll();
+    res.json(patterns);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'No se pudieron obtener patrones.' });
+  }
+};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ import authRoutes from './routes/authRoutes.js';
 import userRoutes from './routes/userRoutes.js';
 import bingoCardRoutes from './routes/bingoCardRoutes.js';
 import adminBingoRoutes from './routes/adminBingoRoutes.js';
+import bingoPatternRoutes from './routes/bingoPatternRoutes.js';
 
 dotenv.config();
 
@@ -28,6 +29,9 @@ app.use('/api/cards', bingoCardRoutes);
 
 // Routes for admin bingo management
 app.use('/api/admin/cards', adminBingoRoutes);
+
+// Routes for bingo patterns
+app.use('/api/patterns', bingoPatternRoutes);
 
 // Base route
 app.get('/', (req, res) => {

--- a/backend/src/models/BingoPattern.js
+++ b/backend/src/models/BingoPattern.js
@@ -1,0 +1,23 @@
+import client from '../config/db.js';
+
+export class BingoPattern {
+  static async create(name, description, pattern) {
+    const result = await client.execute(
+      `INSERT INTO bingo_patterns (name, description, pattern)
+       VALUES (?, ?, ?)`,
+      [name, description, JSON.stringify(pattern)]
+    );
+    return result;
+  }
+
+  static async findAll() {
+    const result = await client.execute(`SELECT * FROM bingo_patterns`);
+    const rows = result.rows ?? result[0]; 
+    return rows.map(row => ({
+      id: row[0],
+      name: row[1],
+      description: row[2],
+      pattern: JSON.parse(row[3]) 
+    }));
+  }
+}

--- a/backend/src/routes/bingoPatternRoutes.js
+++ b/backend/src/routes/bingoPatternRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { createPattern, getAllPatterns } from '../controllers/bingoPatternController.js';
+import { authenticateToken } from '../middlewares/authMiddleware.js';
+import { isAdmin } from '../middlewares/isAdmin.js'; 
+
+const router = express.Router();
+
+router.post('/', authenticateToken, isAdmin, createPattern);
+router.get('/', authenticateToken, getAllPatterns);
+
+export default router;


### PR DESCRIPTION
This PR introduces a new resource for managing game patterns:

- Added a model for handling `bingo_patterns` data.
- Supports creating a new pattern via POST, with a 5x5 matrix.
- Supports listing all patterns with simplified response structure.

These endpoints will support dynamic game modes and pattern-based win validations.