### PR TITLE
Delete user account Aaong with related data

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -73,6 +73,7 @@ export const deleteAccount = async (req, res) => {
       return res.status(200).json({ success: false, message: 'Contraseña incorrecta.' });
     }
 
+    await User.deleteRelations(userId);  
     const deleted = await User.deleteById(userId);
 
     if (!deleted) {


### PR DESCRIPTION
This PR adds functionality to securely delete user accounts from the backend. The deletion process includes:

- Removal of all associated data: winning_cards, marked_numbers, and reservations.
- Updating games to nullify winner references linked to the user.
- Final deletion of the user from the database.