### PR TITLE
Add reservation ID to bingo cards fetched by user

### DIFF
--- a/backend/src/models/BingoCard.js
+++ b/backend/src/models/BingoCard.js
@@ -29,6 +29,7 @@ export class BingoCard {
     const query = `
       SELECT 
         bc.*, 
+        r.id AS reservation_id,
         r.payment_status, 
         r.is_gift
       FROM bingo_cards bc 


### PR DESCRIPTION
This update modifies the `findAllByUser` method in the BingoCard model to include the reservation ID (`reservation_id`) when fetching cards associated with a user.

- Adds `r.id AS reservation_id` to the SQL SELECT query.
- Enables frontend to access and manage reservations directly from card data.

