### PR TITLE
Implement admin feature to manually release used bingo cards

### DIFF
--- a/backend/src/controllers/adminBingoController.js
+++ b/backend/src/controllers/adminBingoController.js
@@ -1,4 +1,5 @@
 import { BingoCard } from '../models/BingoCard.js';
+import { SelectedCard } from '../models/SelectedCard.js';
 
 export const getReservedCards = async (req, res) => {
   try {
@@ -85,6 +86,32 @@ export const approveAllReservations = async (req, res) => {
     res.status(500).json({
       success: false,
       message: 'Ocurrió un error al procesar la solicitud.'
+    });
+  }
+};
+
+export const releaseUsedCards = async (req, res) => {
+  try {
+    const usedReservationIds = await SelectedCard.getUsedReservationIds();
+
+    if (!usedReservationIds.length) {
+      return res.status(200).json({
+        success: true,
+        message: 'No se encontraron cartones usados para liberar.'
+      });
+    }
+
+    await BingoCard.cancelReservationsByIds(usedReservationIds);
+
+    return res.status(200).json({
+      success: true,
+      message: 'Cartones usados, liberados exitosamente.'
+    });
+  } catch (error) {
+    console.error('Error al liberar los cartones usados:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Error interno del servidor.'
     });
   }
 };

--- a/backend/src/models/SelectedCard.js
+++ b/backend/src/models/SelectedCard.js
@@ -29,4 +29,10 @@ export class SelectedCard {
     if (!result.rows || result.rows.length === 0) return [];
     return result.rows.map(row => new SelectedCard(row));
   }
+
+  static async getUsedReservationIds() {
+    const query = `SELECT DISTINCT reservation_id FROM selected_cards`;
+    const result = await client.execute(query);
+    return result.rows.map(row => row.reservation_id);
+  }
 }

--- a/backend/src/routes/adminBingoRoutes.js
+++ b/backend/src/routes/adminBingoRoutes.js
@@ -1,13 +1,14 @@
 import express from 'express';
 import { authenticateToken } from '../middlewares/authMiddleware.js';
 import { isAdmin } from '../middlewares/isAdmin.js';
-import { getReservedCards, approveReservation, rejectReservation, approveAllReservations  } from '../controllers/adminBingoController.js';
+import * as AdminBingoController from '../controllers/adminBingoController.js';
 
 const router = express.Router();
 
-router.get('/reserved', authenticateToken, isAdmin, getReservedCards);
-router.post('/approve', authenticateToken, isAdmin, approveReservation);
-router.post('/reject', authenticateToken, isAdmin, rejectReservation);
-router.post('/approve-all', authenticateToken, isAdmin, approveAllReservations);
+router.get('/reserved', authenticateToken, isAdmin, AdminBingoController.getReservedCards);
+router.post('/approve', authenticateToken, isAdmin, AdminBingoController.approveReservation);
+router.post('/reject', authenticateToken, isAdmin, AdminBingoController.rejectReservation);
+router.post('/approve-all', authenticateToken, isAdmin, AdminBingoController.approveAllReservations);
+router.patch('/release-used-cards', authenticateToken, isAdmin, AdminBingoController.releaseUsedCards);
 
 export default router;


### PR DESCRIPTION
This PR introduces functionality that allows administrators to manually release bingo cards that were used in past games. 

Key changes include:
- A new controller method (`releaseUsedCards`) that checks for used reservations via the `selected_cards` table.
- A model method that updates the reservation status to `'canceled'`, effectively releasing the card.
- Safety checks to ensure no unnecessary updates are made when there are no used cards.