### PR TITLE
Fetch bingo card by ID

### DIFF
--- a/backend/src/controllers/bingoCardController.js
+++ b/backend/src/controllers/bingoCardController.js
@@ -65,7 +65,6 @@ export const getAvailableCards = async (req, res) => {
   }
 };
 
-
 export const reserveCard = async (req, res) => {
   try {
     const cardId = req.params.id;
@@ -111,5 +110,28 @@ export const cancelReservedCard = async (req, res) => {
     });
   } catch (err) {
     res.status(500).json({ message: 'Error al cancelar reserva del cartón.' });
+  }
+};
+
+export const getCardByIdAdmin = async (req, res) => {
+  const cardId = req.params.id;
+
+  try {
+    const card = await BingoCard.findById(cardId);
+
+    if (!card) {
+      return res.status(200).json({
+        success: false,
+        message: 'Cartón no encontrado.'
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      data: card
+    });
+  } catch (err) {
+    console.error('Error al obtener el cartón.', err);
+    res.status(500).json({ message: 'Error al obtener el cartón.' });
   }
 };

--- a/backend/src/routes/bingoCardRoutes.js
+++ b/backend/src/routes/bingoCardRoutes.js
@@ -1,28 +1,26 @@
 import { Router } from 'express';
 import { authenticateToken } from '../middlewares/authMiddleware.js';
-import {
-  getCardById,
-  getUserCards,
-  getAvailableCards,
-  reserveCard,
-  cancelReservedCard
-} from '../controllers/bingoCardController.js';
+import * as BingoCardController from '../controllers/bingoCardController.js';
+import { isAdmin } from '../middlewares/isAdmin.js';
 
 const router = Router();
 
 // Bingo Card Routes
-router.get('/', authenticateToken, getUserCards);
+router.get('/', authenticateToken, BingoCardController.getUserCards);
 
 // Route to get available bingo cards
-router.get('/available', authenticateToken, getAvailableCards);
+router.get('/available', authenticateToken, BingoCardController.getAvailableCards);
 
 // Route to get a specific bingo card by ID
-router.get('/:id', authenticateToken, getCardById);
+router.get('/:id', authenticateToken, BingoCardController.getCardById);
 
 // Route to reserve a bingo card
-router.post('/reserve/:id', authenticateToken, reserveCard);
+router.post('/reserve/:id', authenticateToken, BingoCardController.reserveCard);
 
 // Route to cancel a reserved bingo card
-router.put('/:id/cancel', authenticateToken, cancelReservedCard);
+router.put('/:id/cancel', authenticateToken, BingoCardController.cancelReservedCard);
+
+// Route to get a specific bingo card by ID for admin
+router.get('/:id/admin', authenticateToken, isAdmin, BingoCardController.getCardByIdAdmin);
 
 export default router;


### PR DESCRIPTION
This PR introduces an admin-only endpoint to fetch bingo card details by ID. 

Key points:
- Admins can retrieve any card regardless of reservation status.
- Endpoint: GET /api/cards/:id/admin
- Returns card information including `id` and `numbers`.
- Protected with authentication and admin middleware.

